### PR TITLE
disable to add option -std-c++11 to CXXFLAGS

### DIFF
--- a/build_hmc.sh
+++ b/build_hmc.sh
@@ -17,7 +17,7 @@ set -E -o pipefail
 
 CMAKE_OPT="-DBUILD_MULTI_CONTACT_MOTION_SOLVER=ON"
 export CMAKE_ADDITIONAL_OPTIONS=$CMAKE_OPT
-export CXXFLAGS="$CXXFLAGS -std=c++11"
+#export CXXFLAGS="$CXXFLAGS -std=c++11"
 echo "entering $DRCUTIL_DIR"
 cd $DRCUTIL_DIR
 source config.sh


### PR DESCRIPTION
Since hmc's CMakeLists.txt files are changed for c++11, 
CXXFLAGS in build_hmc.sh  is disabled to add option -std-c++11.

For everybody, if you already installed through jrlutil.sh,
please delete -std-c++11 from cmake option in hmc (we can comfirm when pushing 't'  at ccmake in hmc repository'